### PR TITLE
v1.9.5

### DIFF
--- a/Database.cs
+++ b/Database.cs
@@ -320,11 +320,11 @@ namespace ResearchBodies
                         CB.Value.isResearched = true;
                         CB.Value.researchState = 100;
                     }
-                    else
-                    {
-                        CB.Value.isResearched = false;
-                        CB.Value.researchState = 0;
-                    }
+                    //else
+                    //{
+                    //    CB.Value.isResearched = false;
+                    //    CB.Value.researchState = 0;
+                    //}
                 }
             }
             else
@@ -338,6 +338,15 @@ namespace ResearchBodies
             foreach (KeyValuePair<CelestialBody, CelestialBodyInfo> CB in CelestialBodies)
             {
                 CB.Value.ignore = true;
+            }
+        }
+
+        public void ResetBodiesforLoad()
+        {
+            foreach (KeyValuePair<CelestialBody, CelestialBodyInfo> CB in CelestialBodies)
+            {
+                CB.Value.isResearched = false;
+                CB.Value.researchState = 0;
             }
         }
 

--- a/Database.cs
+++ b/Database.cs
@@ -350,6 +350,19 @@ namespace ResearchBodies
             }
         }
 
+        public void ReApplyRanges()
+        {
+            ConfigNode[] modNodes = GameDatabase.Instance.GetConfigNodes("RESEARCHBODIES");
+            foreach (ConfigNode node in modNodes)
+            {
+                if (!node.HasValue("loadAs"))
+                {
+                    node.TryGetValue("observatorylvl1range", ref Observatorylvl1Range);
+                    node.TryGetValue("observatorylvl2range", ref Observatorylvl2Range);                    
+                }
+            }
+        }
+
         public void ApplySettings()
         {
             RSTLogWriter.Log("Database ApplySettings");

--- a/Distribution/GameData/REPOSoftTech/ResearchBodies/Changelog.txt
+++ b/Distribution/GameData/REPOSoftTech/ResearchBodies/Changelog.txt
@@ -1,4 +1,8 @@
-﻿V1.9.4 (08-05-2017) ==
+﻿V1.9.5 (08-14-2017) ==
+*Fix fix loading different saves in the one KSP session to show body visibility correctly.
+*Fix fix discovery of bodies via telescopes and contracts actually appearing in the Observatory (related to the previous).
+*Fix the OBservatory background texture not showing in any other UI window that uses the default KSP UI skin.
+V1.9.4 (08-05-2017) ==
 *Fix Tracking Station and Observatory Upgrade Level checks for contracts.
 *Fix Range checks for Observatory and Vessels with Telescopes for contracts.
 *Fix MapNodes appearing in MapView when there are orbits available for any contracts.

--- a/Distribution/GameData/REPOSoftTech/ResearchBodies/Changelog.txt
+++ b/Distribution/GameData/REPOSoftTech/ResearchBodies/Changelog.txt
@@ -2,6 +2,7 @@
 *Fix fix loading different saves in the one KSP session to show body visibility correctly.
 *Fix fix discovery of bodies via telescopes and contracts actually appearing in the Observatory (related to the previous).
 *Fix the OBservatory background texture not showing in any other UI window that uses the default KSP UI skin.
+*Show the correct Observatory Ranges when Kopernicus is installed in the Observatory Facility upgrade stats window.
 V1.9.4 (08-05-2017) ==
 *Fix Tracking Station and Observatory Upgrade Level checks for contracts.
 *Fix Range checks for Observatory and Vessels with Telescopes for contracts.

--- a/Distribution/GameData/REPOSoftTech/ResearchBodies/ResearchBodies.version
+++ b/Distribution/GameData/REPOSoftTech/ResearchBodies/ResearchBodies.version
@@ -2,7 +2,7 @@
 	"NAME":"ResearchBodies",
 	"URL":"http://ksp-avc.cybutek.net/version.php?id=295",
 	"DOWNLOAD":"http://spacedock.info/mod/684/ResearchBodies",
-	"VERSION":{"MAJOR":1,"MINOR":9,"PATCH":4,"BUILD":0},
+	"VERSION":{"MAJOR":1,"MINOR":9,"PATCH":5,"BUILD":0},
 	"KSP_VERSION":{"MAJOR":1,"MINOR":3,"PATCH":0},
 	"KSP_VERSION_MIN":{"MAJOR":1,"MINOR":3,"PATCH":0},
 	"KSP_VERSION_MAX":{"MAJOR":1,"MINOR":3,"PATCH":0}

--- a/Distribution/GameData/REPOSoftTech/ResearchBodies/ResearchBodiesMMKopernicus.cfg
+++ b/Distribution/GameData/REPOSoftTech/ResearchBodies/ResearchBodiesMMKopernicus.cfg
@@ -16,6 +16,6 @@
 
 @RESEARCHBODIES:FOR[ResearchBodies]:NEEDS[Kopernicus]
 {
-	%observatorylvl1range = 700000000000
-	%observatorylvl2range = 5000000000000
+	@observatorylvl1range = 700000000000
+	@observatorylvl2range = 5000000000000
 }                           

--- a/Observatory.cs
+++ b/Observatory.cs
@@ -54,6 +54,7 @@ namespace ResearchBodies
         private Vector3 groundBaseOffset = new Vector3(15f, -9f, -10f); //new Vector3(0f, 0f, 0f);//new Vector3(15f, -9f, -10f);
         private float Observatorylvl1Range = 0f;
         private float Observatorylvl2Range = 0f;
+        private bool lvlStatsNotSet = true;
 
         /// <summary>
         /// Check and establish singleton.
@@ -763,6 +764,29 @@ namespace ResearchBodies
                     RSTLogWriter.Log("Failed to Inject Observatory SpaceCenter Facility cannot continue setup of this Facility");
                     return;
                 }
+
+                if (lvlStatsNotSet)
+                {
+                    upgradeablefacility.UpgradeLevels[0].levelText.textBase = Locales.FmtLocaleString("#autoLOC_RBodies_00097") + "\n";
+                    string rngString1 = KSP.Localization.Localizer.Format("<<1>>", Database.instance.Observatorylvl1Range.ToString("F0"));
+                    upgradeablefacility.UpgradeLevels[0].levelText.textBase += Locales.FmtLocaleString("#autoLOC_RBodies_00098", rngString1);
+                    upgradeablefacility.UpgradeLevels[0].levelText.linePrefix = "* ";
+                    upgradeablefacility.UpgradeLevels[0].levelStats = new Upgradeables.KSCFacilityLevelText();
+                    upgradeablefacility.UpgradeLevels[0].levelStats.linePrefix = upgradeablefacility.UpgradeLevels[0].levelText.linePrefix;
+                    upgradeablefacility.UpgradeLevels[0].levelStats.facility = SpaceCenterFacility.TrackingStation;
+                    upgradeablefacility.UpgradeLevels[0].levelStats.textBase = upgradeablefacility.UpgradeLevels[0].levelText.textBase;
+
+                    upgradeablefacility.UpgradeLevels[1].levelText.textBase = Locales.FmtLocaleString("#autoLOC_RBodies_00097") + "\n";
+                    string rngString2 = KSP.Localization.Localizer.Format("<<1>>", Database.instance.Observatorylvl2Range.ToString("F0"));
+                    upgradeablefacility.UpgradeLevels[1].levelText.textBase += Locales.FmtLocaleString("#autoLOC_RBodies_00098", rngString2);
+                    upgradeablefacility.UpgradeLevels[1].levelText.linePrefix = "* ";
+                    upgradeablefacility.UpgradeLevels[1].levelStats = new Upgradeables.KSCFacilityLevelText();
+                    upgradeablefacility.UpgradeLevels[1].levelStats.linePrefix = upgradeablefacility.UpgradeLevels[1].levelText.linePrefix;
+                    upgradeablefacility.UpgradeLevels[1].levelStats.facility = SpaceCenterFacility.TrackingStation;
+                    upgradeablefacility.UpgradeLevels[1].levelStats.textBase = upgradeablefacility.UpgradeLevels[1].levelText.textBase;
+                    lvlStatsNotSet = false;
+                }
+
                 RSTLogWriter.Log_Debug("Scene SpaceCenter");
                 //Scan the PQS for our home planet.
                 pqscities = Resources.FindObjectsOfTypeAll<PQSCity>();

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.9.4.0")]
-[assembly: AssemblyFileVersion("1.9.4.0")]
+[assembly: AssemblyVersion("1.9.5.0")]
+[assembly: AssemblyFileVersion("1.9.5.0")]

--- a/RBGameSettings.cs
+++ b/RBGameSettings.cs
@@ -76,7 +76,7 @@ namespace ResearchBodies
                         if (bodyNode.HasValue("body"))
                         {
                             CelestialBodyInfo bodyInfo = CelestialBodyInfo.Load(bodyNode);
-                            CelestialBody CB = FlightGlobals.Bodies.FirstOrDefault(a => a.GetName() == bodyInfo.body);
+                            CelestialBody CB = FlightGlobals.Bodies.FirstOrDefault(a => a.bodyName == bodyInfo.body);
                             if (CB != null)
                             {
                                 Database.instance.CelestialBodies[CB].isResearched = bodyInfo.isResearched;

--- a/ResearchBodies.cs
+++ b/ResearchBodies.cs
@@ -81,6 +81,7 @@ namespace ResearchBodies
 
         public override void OnLoad(ConfigNode gameNode)
         {
+            Database.instance.ResetBodiesforLoad();
             base.OnLoad(gameNode);
             RBgameSettings.Load(gameNode);
             if (Database.instance.RB_SettingsParms != null)

--- a/ResearchBodiesController.cs
+++ b/ResearchBodiesController.cs
@@ -61,6 +61,11 @@ namespace ResearchBodies
             if (HighLogic.CurrentGame.Mode == Game.Modes.CAREER)
                 GameEvents.Contract.onOffered.Add(CheckContracts);
 
+            if (Utilities.IsKopInstalled)
+            {
+                Database.instance.ReApplyRanges();
+            }
+
             //If RB is enabled set initial Discovery Levels of CBs and call ProgressiveCBMaps to set their graphics levels.
             if (enable)
             {

--- a/Textures.cs
+++ b/Textures.cs
@@ -95,7 +95,7 @@ namespace ResearchBodies
             if (HighLogic.Skin != null)
             {
                 GUI.skin = HighLogic.Skin;
-                ObsSkin = HighLogic.Skin;
+                ObsSkin = GameObject.Instantiate(HighLogic.Skin);
                 ObsSkin.window.normal.background = ObsWinBgnd;
                 ObsSkin.window.active.background = ObsWinBgnd;
                 ObsSkin.window.onActive.background = ObsWinBgnd;


### PR DESCRIPTION
*Fix fix loading different saves in the one KSP session to show body visibility correctly.
*Fix fix discovery of bodies via telescopes and contracts actually appearing in the Observatory (related to the previous).
*Fix the OBservatory background texture not showing in any other UI window that uses the default KSP UI skin.
*Show the correct Observatory Ranges when Kopernicus is installed in the Observatory Facility upgrade stats window.

