### PR TITLE
change Kerbin to HomeWorld() in contracts

### DIFF
--- a/Distribution/GameData/REPOSoftTech/ResearchBodies/Contracts/CC_RB_ResearchBodyContract.cfg
+++ b/Distribution/GameData/REPOSoftTech/ResearchBodies/Contracts/CC_RB_ResearchBodyContract.cfg
@@ -24,7 +24,7 @@ CONTRACT_TYPE
 	declinable = true
 	maxSimultaneous = 1	
 	//prestige = Significant
-	//targetBody = Kerbin	
+	//targetBody = HomeWorld()	
 	//rewardScience = 100.0
     //rewardReputation = 20.0
     //rewardFunds = 100000.0

--- a/Distribution/GameData/REPOSoftTech/ResearchBodies/Contracts/CC_RB_SearchSkiesContract.cfg
+++ b/Distribution/GameData/REPOSoftTech/ResearchBodies/Contracts/CC_RB_SearchSkiesContract.cfg
@@ -26,7 +26,7 @@ CONTRACT_TYPE
 	maxSimultaneous = 1
 	
 	//prestige = Significant
-	//targetBody = Kerbin
+	//targetBody = HomeWorld()
 	
 	//rewardScience = 100.0
     //rewardReputation = 20.0

--- a/Distribution/GameData/REPOSoftTech/ResearchBodies/Contracts/CC_RB_TelescopeResearchBodyContract.cfg
+++ b/Distribution/GameData/REPOSoftTech/ResearchBodies/Contracts/CC_RB_TelescopeResearchBodyContract.cfg
@@ -24,7 +24,7 @@ CONTRACT_TYPE
 	declinable = true
 	maxSimultaneous = 1	
 	//prestige = Significant
-	//targetBody = Kerbin	
+	//targetBody = HomeWorld()	
 	//rewardScience = 100.0
     //rewardReputation = 20.0
     //rewardFunds = 100000.0
@@ -46,7 +46,7 @@ CONTRACT_TYPE
 	{
 		name = Orbit
 		type = Orbit
-		targetBody = Kerbin
+		targetBody = HomeWorld()
 		situation = ORBITING
 		minAltitude = 200000
 		title = #autoLOC_RBodies_00082 //The vessel must be in orbit above 200000 meters.
@@ -94,7 +94,7 @@ CONTRACT_TYPE
 		// Use this to generate an orbit with some randomization
 		RANDOM_ORBIT
 		{			
-			targetBody = Kerbin			
+			targetBody = HomeWorld()			
 			type = RANDOM
 			// A factor between 0.0 and 1.0 which indicates how high the orbit
 			// can be.  A value of 1.0 indicates the orbit may go as far out as

--- a/Distribution/GameData/REPOSoftTech/ResearchBodies/Contracts/CC_RB_TelescopeSearchSkiesContract.cfg
+++ b/Distribution/GameData/REPOSoftTech/ResearchBodies/Contracts/CC_RB_TelescopeSearchSkiesContract.cfg
@@ -26,7 +26,7 @@ CONTRACT_TYPE
 	maxSimultaneous = 1
 	
 	//prestige = Significant
-	//targetBody = Kerbin
+	//targetBody = HomeWorld()
 	
 	//rewardScience = 100.0
     //rewardReputation = 20.0
@@ -48,7 +48,7 @@ CONTRACT_TYPE
 	{
 		name = Orbit
 		type = Orbit
-		targetBody = Kerbin
+		targetBody = HomeWorld()
 		situation = ORBITING
 		minAltitude = 200000
 		title = #autoLOC_RBodies_00091 //The vessel must be in orbit above 200000 meters.
@@ -96,7 +96,7 @@ CONTRACT_TYPE
 		// Use this to generate an orbit with some randomization
 		RANDOM_ORBIT
 		{			
-			targetBody = Kerbin			
+			targetBody = HomeWorld()			
 			type = RANDOM
 			// A factor between 0.0 and 1.0 which indicates how high the orbit
 			// can be.  A value of 1.0 indicates the orbit may go as far out as


### PR DESCRIPTION
For planet packs where home world is not "Kerbin" (like GPP), use CC function HomeWorld() to get the correct home world.